### PR TITLE
Changed texture2D to texture

### DIFF
--- a/shaders/copy.frag
+++ b/shaders/copy.frag
@@ -8,6 +8,7 @@ out vec4 frag_color;
 uniform sampler2D u_texture;
 
 void main()
-{
-	frag_color = vec4(texture2D(u_texture, v_texcoord).rgb, 1.);
+{	
+
+	frag_color = vec4(texture(u_texture, v_texcoord).rgb, 1.);
 }

--- a/shaders/density/advection.frag
+++ b/shaders/density/advection.frag
@@ -13,8 +13,8 @@ uniform sampler2D u_velocity;
 
 void main()
 {
-	vec2 velocity = texture2D(u_velocity, v_texcoord).xy;
+	vec2 velocity = texture(u_velocity, v_texcoord).xy;
 	vec2 prev_pos = v_texcoord - ((velocity * u_time_step) / u_screen);
 	vec3 dissipation = vec3(u_dissipation * 1.75, u_dissipation * 1., u_dissipation * 0.75);
-	frag_color = vec4(texture2D(u_density, prev_pos).rgb * (1. - dissipation), 1.);
+	frag_color = vec4(texture(u_density, prev_pos).rgb * (1. - dissipation), 1.);
 }

--- a/shaders/density/diffusion.frag
+++ b/shaders/density/diffusion.frag
@@ -13,13 +13,13 @@ uniform sampler2D u_density_temp;
 
 vec3 get_density(float x, float y)
 {
-	return texture2D(u_density_temp, v_texcoord + vec2(x, y) / u_screen).rgb;
+	return texture(u_density_temp, v_texcoord + vec2(x, y) / u_screen).rgb;
 }
 
 void main()
 {
 	float k = u_time_step * u_viscosity * u_screen.x * u_screen.y;
-	vec3 d = texture2D(u_density, v_texcoord).rgb;
+	vec3 d = texture(u_density, v_texcoord).rgb;
 	vec3 density = (d + k * (get_density(-1., 0.) + get_density(1., 0.) + get_density(0., -1.) + get_density(0., 1.))) / (1. + 4. * k);
 	frag_color = vec4(density, 1.);
 }

--- a/shaders/density/sources.frag
+++ b/shaders/density/sources.frag
@@ -21,5 +21,5 @@ void main()
 	vec2 screen = 100. * u_screen / ((u_screen.x + u_screen.y) / 2.);
 	vec2 coord = (u_mouse - v_texcoord) * screen;
 	vec3 splat = u_color.rgb * exp(-dot(coord, coord) / u_strength) * 0.3;
-	frag_color = vec4(clamp(texture2D(u_density, v_texcoord).rgb + splat, 0., 1.), 1.);
+	frag_color = vec4(clamp(texture(u_density, v_texcoord).rgb + splat, 0., 1.), 1.);
 }

--- a/shaders/render/density.frag
+++ b/shaders/render/density.frag
@@ -10,5 +10,5 @@ uniform sampler2D u_texture;
 
 void main()
 {
-	frag_color = vec4(texture2D(u_texture, v_texcoord).rgb, 1.);
+	frag_color = vec4(texture(u_texture, v_texcoord).rgb, 1.);
 }

--- a/shaders/render/divergence.frag
+++ b/shaders/render/divergence.frag
@@ -10,7 +10,7 @@ uniform sampler2D u_texture;
 
 void main()
 {
-	float divergence = texture2D(u_texture, v_texcoord).r * 70.;
+	float divergence = texture(u_texture, v_texcoord).r * 70.;
 	vec3 color;
 
 	if (divergence < 0.)

--- a/shaders/render/pressure.frag
+++ b/shaders/render/pressure.frag
@@ -10,7 +10,7 @@ uniform sampler2D u_texture;
 
 void main()
 {
-	float pressure = texture2D(u_texture, v_texcoord).r * 30.;
+	float pressure = texture(u_texture, v_texcoord).r * 30.;
 	vec3 color;
 
 	if (pressure < 0.)

--- a/shaders/render/velocity.frag
+++ b/shaders/render/velocity.frag
@@ -10,5 +10,5 @@ uniform sampler2D u_texture;
 
 void main()
 {
-	frag_color = vec4(texture2D(u_texture, v_texcoord).rgb / 10. + 0.5, 1.);
+	frag_color = vec4(texture(u_texture, v_texcoord).rgb / 10. + 0.5, 1.);
 }

--- a/shaders/velocity/advection.frag
+++ b/shaders/velocity/advection.frag
@@ -12,7 +12,7 @@ uniform sampler2D u_velocity;
 
 void main()
 {
-	vec2 velocity = texture2D(u_velocity, v_texcoord).xy;
+	vec2 velocity = texture(u_velocity, v_texcoord).xy;
 	vec2 prev_pos = v_texcoord - ((velocity * u_time_step) / u_screen);
-	frag_color = vec4(texture2D(u_density, prev_pos).rgb, 1.);
+	frag_color = vec4(texture(u_density, prev_pos).rgb, 1.);
 }

--- a/shaders/velocity/boundaries.frag
+++ b/shaders/velocity/boundaries.frag
@@ -10,7 +10,7 @@ uniform sampler2D u_velocity;
 
 vec2 get_velocity(float x, float y)
 {
-	return texture2D(u_velocity, v_texcoord + vec2(x, y) / u_screen).xy;
+	return texture(u_velocity, v_texcoord + vec2(x, y) / u_screen).xy;
 }
 
 void main()

--- a/shaders/velocity/diffusion.frag
+++ b/shaders/velocity/diffusion.frag
@@ -13,13 +13,13 @@ uniform sampler2D u_velocity_temp;
 
 vec2 get_velocity(float x, float y)
 {
-	return texture2D(u_velocity_temp, v_texcoord + vec2(x, y) / u_screen).xy;
+	return texture(u_velocity_temp, v_texcoord + vec2(x, y) / u_screen).xy;
 }
 
 void main()
 {
 	float k = u_time_step * u_viscosity * u_screen.x * u_screen.y;
-	vec2 v = texture2D(u_velocity, v_texcoord).xy;
+	vec2 v = texture(u_velocity, v_texcoord).xy;
 	vec2 velocity = (v + k * (get_velocity(-1., 0.) + get_velocity(1., 0.) + get_velocity(0., -1.) + get_velocity(0., 1.))) / (1. + 4. * k);
 	frag_color = vec4(velocity, 0., 1.);
 }

--- a/shaders/velocity/divergence.frag
+++ b/shaders/velocity/divergence.frag
@@ -10,7 +10,7 @@ uniform sampler2D u_velocity;
 
 vec2 get_velocity(float x, float y)
 {
-	return texture2D(u_velocity, v_texcoord + vec2(x, y) / u_screen).xy;
+	return texture(u_velocity, v_texcoord + vec2(x, y) / u_screen).xy;
 }
 
 void main()

--- a/shaders/velocity/forces.frag
+++ b/shaders/velocity/forces.frag
@@ -17,5 +17,5 @@ void main()
 	vec2 move = (u_mouse - u_prev_mouse) * screen;
 	vec2 coord = (u_mouse - v_texcoord) * screen;
 	vec2 splat = move * exp(-dot(coord, coord) / u_strength);
-	frag_color = vec4(texture2D(u_velocity, v_texcoord).xy + splat, 0., 1.);
+	frag_color = vec4(texture(u_velocity, v_texcoord).xy + splat, 0., 1.);
 }

--- a/shaders/velocity/gradient.frag
+++ b/shaders/velocity/gradient.frag
@@ -10,7 +10,7 @@ uniform sampler2D u_pressure;
 
 float get_pressure(float x, float y)
 {
-	return texture2D(u_pressure, v_texcoord + vec2(x, y) / u_screen).x;
+	return texture(u_pressure, v_texcoord + vec2(x, y) / u_screen).x;
 }
 
 void main()

--- a/shaders/velocity/pressure.frag
+++ b/shaders/velocity/pressure.frag
@@ -11,12 +11,12 @@ uniform sampler2D u_pressure;
 
 float get_pressure(float x, float y)
 {
-	return texture2D(u_pressure, v_texcoord + vec2(x, y) / u_screen).x;
+	return texture(u_pressure, v_texcoord + vec2(x, y) / u_screen).x;
 }
 
 void main()
 {
-	float d = texture2D(u_divergence, v_texcoord).x;
+	float d = texture(u_divergence, v_texcoord).x;
 	float pressure = (d + get_pressure(-1., 0.) + get_pressure(1., 0.) + get_pressure(0., -1.) + get_pressure(0., 1.)) / 4.;
 	frag_color = vec4(pressure, 0., 0., 1.);
 }

--- a/shaders/velocity/subtraction.frag
+++ b/shaders/velocity/subtraction.frag
@@ -10,6 +10,6 @@ uniform sampler2D u_gradient;
 
 void main()
 {
-	vec2 velocity = texture2D(u_velocity, v_texcoord).xy - texture2D(u_gradient, v_texcoord).xy;
+	vec2 velocity = texture(u_velocity, v_texcoord).xy - texture(u_gradient, v_texcoord).xy;
 	frag_color = vec4(velocity, 0., 1.);
 }

--- a/shaders/velocity/vorticity.frag
+++ b/shaders/velocity/vorticity.frag
@@ -12,7 +12,7 @@ uniform sampler2D u_velocity;
 
 vec2 get_velocity(float x, float y)
 {
-	return texture2D(u_velocity, v_texcoord + vec2(x, y) / u_screen).xy;
+	return texture(u_velocity, v_texcoord + vec2(x, y) / u_screen).xy;
 }
 
 float get_curl(float x, float y)


### PR DESCRIPTION
Hi! I'm new with fluid simulations and I discovered your project, nice job ;)

I compiled the project but got compilation error of shaders at runtime, but I found out that changing texture2D to simply texture this error was gone.

I'm not an expert with opengl or glsl, so maybe it's not the best idea to merge this, but it worked for me ^^
ty and good luck!

Error: (when I changed texture2D to texture in copy.frag I just keep getting errors of other shaders)

Failed to compile fragment shader:
0:39(74): error: no function with name 'texture2D'
0:39(61): error: operands to arithmetic operators must be numeric
0:39(23): error: operands to arithmetic operators must be numeric
0:63(19): warning: `initial_color' used uninitialized
0:68(19): warning: `initial_color' used uninitialized
0:77(68): warning: `initial_color' used uninitialized
0:81(15): warning: `initial_color' used uninitialized

Failed to compile fragment shader:
0:12(20): error: no function with name 'texture2D'
0:12(20): error: type mismatch
0:12(15): error: cannot construct `vec4' from a non-numeric data type

terminate called after throwing an instance of 'std::runtime_error'
  what():  The shader shaders/all.vert or shaders/copy.frag could not be loaded
Aborted (core dumped)


